### PR TITLE
Add crystal-docs website to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
 # Services and Apps
  * [carc.in](https://carc.in/) - A web service that runs your code and displays the result
  * [Crank](https://github.com/arktisklada/crank) - A Procfile-based application manager (like Foreman)
+ * [crystal-docs](https://crystal-docs.org) - A service for hosting Crystal Shard documentation
  * [crystalshards](https://crystalshards.herokuapp.com/) - A web service that lists all available Crystal shards
  * [DeBot](https://github.com/jhass/DeBot) - IRC bot written in Crystal
  * [docrystal](http://docrystal.org/) - A web application that hosts documentation for Crystal packages


### PR DESCRIPTION
After merging this pull request the `awesome-crystal` list will include a reference to the [crystal-docs](https://crystal-docs.org) website.

It may be worth noting that the `docrystal` project has been broken for awhile now (at least a few months) as it compiles the documentation for shards, which requires that both the compiler and the shards are compatible, which seems to never be the case.
