### PR TITLE
Add `ms` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [kreal](https://github.com/f/kreal) - Model sharing & RPC library built on and works with Kemal seamlessly
  * [lambda.cr](https://github.com/f/lambda.cr) - Uniformed function call syntax
  * [metaclass](https://github.com/mosop/metaclass) - A library for manipulating class-level definitions
+ * [ms](https://github.com/SuperPaintman/ms) - Library to easily convert various time formats to milliseconds and milliseconds to human readable format.
  * [observable](https://github.com/TPei/observable) - Implementation of the Observer pattern
  * [promise](https://github.com/jwaldrip/promise-cr) - A Promise Implementation
  * [ramlrenderer](https://github.com/beno/ramlrenderer) - HTLM doc builder for RAML 1.0


### PR DESCRIPTION
Hi! I added my `ms` library.

It helps convert time formats (like `5 sec` / `1 year` / `day`) to milliseconds, and milliseconds to human readable format.

```crystal
require "ms"

MS.ms("50 min")
# => 3000000

MS.ms(1000)
# => "1s"
```