### PR TITLE
Add kemal-rest-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
 
 ## Api Builders
  * [crystal_api](https://github.com/akwiatkowski/crystal_api) - Simple PostgreSQL REST API with Rails devise-like auth
+ * [kemal-rest-api](https://github.com/blocknotes/kemal-rest-api) - A library to create RESTful API with Kemal
 
 ## Caching
  * [Bloom Filter](https://github.com/greyblake/crystal-bloom_filter) - Implementation of Bloom filter


### PR DESCRIPTION
[kemal-rest-api](https://github.com/blocknotes/kemal-rest-api)

Added to **Api Builders** section

- [x] Tests pass (`crystal spec`)
- [x] Description of the entry is clear and concise. There is no excessive information like
      **"... for Crystal programming language"**,
      **"... for Crystal"**,
      **"... written in Crystal"** etc.
