### PR TITLE
Add mime-types.cr

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [kemal-redis](https://github.com/sdogruyol/kemal-redis) - Easily add Redis to Kemal
  * [kemal-session](https://github.com/Thyra/kemal-session) - Session handler for Kemal
  * [kemalyst-i18n](https://github.com/TechMagister/kemalyst-i18n) - i18n support for Kemalyst
+ * [mime-types.cr](https://github.com/jwaldrip/mime-types.cr) - A port of the Ruby MIME-types library
  * [response_time](https://github.com/SuperPaintman/response-time) - Response time for Crystal servers (pure http server, kemal, etc.)
  * [spec-kemal](https://github.com/sdogruyol/spec-kemal) - Easy testing for Kemal
  * [toro](https://github.com/soveran/toro) - Tree Oriented Routing


### PR DESCRIPTION
[mime-types.cr](https://github.com/jwaldrip/mime-types.cr) - A port of the Ruby MIME-types library

Added to **Framework Components** section

- [x] Tests pass (`crystal spec`)
- [x] Description of the entry is clear and concise. There is no excessive information like
      **"... for Crystal programming language"**,
      **"... for Crystal"**,
      **"... written in Crystal"** etc.
