### PR TITLE
Add ipaddress.cr shard

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [bson.cr](https://github.com/jeromegn/bson.cr) - Native BSON implementation
  * [CrystalIrc](https://github.com/Meoowww/CrystalIrc) - IRC implementation (Client, Server, Bots)
  * [fast_irc.cr](https://github.com/RX14/fast_irc.cr) - Fast IRC parser/generator
+ * [ipaddress.cr](https://github.com/Sija/ipaddress.cr) - Library to handle IPv4 and IPv6 addresses
  * [jwt](https://github.com/greyblake/crystal-jwt) - Implementation of JWT (JSON Web Token)
  * [msgpack-crystal](https://github.com/benoist/msgpack-crystal) - MessagePack library
  * [sctp-crystal](https://github.com/CodeSteak/sctp-crystal) - SCTP networking library


### PR DESCRIPTION
This PR adds [ipaddress.cr](https://github.com/Sija/ipaddress.cr) shard to the list.

Added to **NETWORKING** section

- [x] Tests pass (`crystal spec`)
- [x] Description of the entry is clear and concise. There is no excessive information like
      **"... for Crystal programming language"**,
      **"... for Crystal"**,
      **"... written in Crystal"** etc.
