### PR TITLE
Add bugsnag.cr

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [AnyBar_cr](https://github.com/davydovanton/AnyBar_cr) - Simple crystal wrapper for AnyBar library
  * [aws-signer.cr](https://github.com/beanieboi/aws-signer.cr) - This library signs your HTTP requests using AWS v4
  * [awscr-signer](https://github.com/taylorfinnell/awscr-signer) - Sign HTTP::Request objects and generate presigned post forms
+ * [bugsnag.cr](https://github.com/gewo/bugsnag.cr) - Bugsnag exception notifier and sidekiq middleware
  * [crystal-connpass](https://github.com/pine/crystal-connpass) - Wrapper for the [Connpass](http://connpass.com/) API
  * [crystal-mondo](https://github.com/barisbalic/crystal-mondo) - A client for the [Mondo API](https://getmondo.co.uk/docs/)
  * [crystal-newrelic](https://github.com/waj/crystal-newrelic) - NewRelic API client


### PR DESCRIPTION
[bugsnag.cr](https://github.com/gewo/bugsnag.cr)

Added to **Third-party APIs** section

- [x] Tests pass (`crystal spec`)
- [x] Description of the entry is clear and concise. There is no excessive information like
      **"... for Crystal programming language"**,
      **"... for Crystal"**,
      **"... written in Crystal"** etc.
