### PR TITLE
Add Admiral

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [Nuummite](https://github.com/CodeSteak/Nuummite) - A tiny persistent embedded key-value store
 
 ## Cli Builders
- * [admiral](https://github.com/jwaldrip/admiral.cr) - A robust DSL for writing command line interfaces.
+ * [admiral](https://github.com/jwaldrip/admiral.cr) - A robust DSL for writing command line interfaces
  * [cli](https://github.com/mosop/cli) - Library for building command-line interface applications
  * [commander](https://github.com/mrrooijen/commander) - Command-line interface builder
  * [completion](https://github.com/f/completion) - Easy command line completion engine

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [Nuummite](https://github.com/CodeSteak/Nuummite) - A tiny persistent embedded key-value store
 
 ## Cli Builders
+ * [admiral](https://github.com/jwaldrip/admiral.cr) - A robust DSL for writing command line interfaces.
  * [cli](https://github.com/mosop/cli) - Library for building command-line interface applications
  * [commander](https://github.com/mrrooijen/commander) - Command-line interface builder
  * [completion](https://github.com/f/completion) - Easy command line completion engine


### PR DESCRIPTION
[admiral](https://github.com/jwaldrip/admiral.cr) - A robust DSL for writing command line interfaces.

Added to **CLI Utils** section

- [x] Tests pass (`crystal spec`)
- [x] Description of the entry is clear and concise. There is no excessive information like
      **"... for Crystal programming language"**,
      **"... for Crystal"**,
      **"... written in Crystal"** etc.
