### PR TITLE
Add Crometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [onix](https://github.com/ozra/onyx-lang) - ONYX Programming Language
 
 ## Logging and monitoring
+ * [crometheus](https://gitlab.com/ezrast/crometheus) - A [Prometheus](https://prometheus.io/) client library
  * [crystal-logreader](https://github.com/arcage/crystal-logreader) - Tailing log file
  * [gelf-crystal](https://github.com/benoist/gelf-crystal) - A GELF logger
  * [syslog.cr](https://github.com/comandeo/syslog.cr) - Implementation of Syslog client

--- a/spec/readme_spec.cr
+++ b/spec/readme_spec.cr
@@ -21,9 +21,18 @@ describe "List of Crystal Awesomeness" do
     end
   end
 
+  it "has references in 'https://gitlab.com/path' format" do
+    readme.get_refs(/gitlab\.com/).each do |ref|
+      uri = URI.parse(ref)
+      uri.scheme.should eq "https"
+      uri.host.should eq "gitlab.com"
+      uri.path.should_not be nil
+    end
+  end
+
   it "hasn't duplicated references" do
     prev = nil
-    readme.get_refs(/github\.com/).map do |ref|
+    readme.get_refs(/git(?:hub|lab)\.com/).map do |ref|
       uri = URI.parse(ref)
       host = uri.host.as String
       path = uri.path.as String | Nil


### PR DESCRIPTION
[crometheus](https://gitlab.com/ezrast/crometheus)

Added to **Logging and monitoring** section

I host on GitLab so I also added analogs for the GitHub-specific test cases.

- [x] Tests pass (`crystal spec`)
- [x] Description of the entry is clear and concise. There is no excessive information like
      **"... for Crystal programming language"**,
      **"... for Crystal"**,
      **"... written in Crystal"** etc.
