### PR TITLE
Added route.cr

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [http_parser.cr](https://github.com/kostya/http_parser.cr) - Wrapper for [Http Parser lib](https://github.com/nodejs/http-parser)
  * [multipart.cr](https://github.com/RX14/multipart.cr) - Adds multipart and multipart/form-data support to the crystal standard library
  * [resp-crystal](https://github.com/soveran/resp-crystal) - Lightweight RESP client
- * [router-simple.cr](https://github.com/karupanerura/router-simple.cr) - Simple path router
  * [route.cr](https://github.com/tbrand/route.cr) - Minimum but powerful http router for HTTP::Server
+ * [router-simple.cr](https://github.com/karupanerura/router-simple.cr) - Simple path router
  * [session](https://github.com/porras/session.git) - Cookie based sessions in Crystal HTTP applications
 
 ## Implementations/Compilers

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [multipart.cr](https://github.com/RX14/multipart.cr) - Adds multipart and multipart/form-data support to the crystal standard library
  * [resp-crystal](https://github.com/soveran/resp-crystal) - Lightweight RESP client
  * [router-simple.cr](https://github.com/karupanerura/router-simple.cr) - Simple path router
+ * [route.cr](https://github.com/tbrand/route.cr) - Minimum but powerful http router for HTTP::Server
  * [session](https://github.com/porras/session.git) - Cookie based sessions in Crystal HTTP applications
 
 ## Implementations/Compilers


### PR DESCRIPTION
[route.cr](https://github.com/tbrand/route.cr)

Added to **route.cr** section

- [x] Tests pass (`crystal spec`)
- [x] Description of the entry is clear and concise. There is no excessive information like
      **"... for Crystal programming language"**,
      **"... for Crystal"**,
      **"... written in Crystal"** etc.
