### PR TITLE
Added crystal-darksky

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [awscr-signer](https://github.com/taylorfinnell/awscr-signer) - Sign HTTP::Request objects and generate presigned post forms
  * [bugsnag.cr](https://github.com/gewo/bugsnag.cr) - Bugsnag exception notifier and sidekiq middleware
  * [crystal-connpass](https://github.com/pine/crystal-connpass) - Wrapper for the [Connpass](http://connpass.com/) API
+ * [crystal-darksky](https://github.com/sb89/crystal-darksky) - Wrapper for the [Dark Sky](https://darksky.net) API
  * [crystal-github](https://github.com/felipeelias/crystal-github) - Wrapper for the [Github](https://github.com/) API
  * [crystal-mondo](https://github.com/barisbalic/crystal-mondo) - A client for the [Mondo API](https://getmondo.co.uk/docs/)
  * [crystal-newrelic](https://github.com/waj/crystal-newrelic) - NewRelic API client


### PR DESCRIPTION
[crystal-darksky](https://github.com/sb89/crystal-darksky)

Added to **Third-party APIs** section

- [x] Tests pass (`crystal spec`)
- [x] Description of the entry is clear and concise. There is no excessive information like
      **"... for Crystal programming language"**,
      **"... for Crystal"**,
      **"... written in Crystal"** etc.
