### PR TITLE
remove sctp-crystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,6 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [ipaddress.cr](https://github.com/Sija/ipaddress.cr) - Library to handle IPv4 and IPv6 addresses
  * [jwt](https://github.com/greyblake/crystal-jwt) - Implementation of JWT (JSON Web Token)
  * [msgpack-crystal](https://github.com/benoist/msgpack-crystal) - MessagePack library
- * [sctp-crystal](https://github.com/CodeSteak/sctp-crystal) - SCTP networking library
 
 ## ORM/ODM Extensions
  * [active_record.cr](https://github.com/waterlink/active_record.cr) - Active Record pattern implementation


### PR DESCRIPTION
Hi,
Thanks for this awesome list!

`sctp-crystal` is currently broken and will most likely be discontinued.