### PR TITLE
Add migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
 ## Database Tools
  * [crecto-admin](https://github.com/Crecto/crecto-admin) - Admin dashboard for Crecto and your database
  * [micrate](https://github.com/juanedi/micrate) - Database migration tool
+ * [migrate](https://github.com/vladfaust/migrate.cr) - A simpler database migration tool with transactions
 
 ## Development Tools
  * [guardian](https://github.com/f/guardian) - File change watcher for Crystal and Non-Crystal libs


### PR DESCRIPTION
[micrate.cr](https://github.com/juanedi/micrate) is abandoned - it has forever pending pull requests with needed features and never updated issues.

I've developed a simpler solution ([migrate](https://github.com/vladfaust/migrate.cr)), which resolves following issues:

- https://github.com/juanedi/micrate/issues/11
- https://github.com/juanedi/micrate/issues/13
- https://github.com/juanedi/micrate/issues/19
- https://github.com/juanedi/micrate/issues/20
- https://github.com/juanedi/micrate/issues/21

It may be possible to migrate from micrate to migrate :smile:: just add a table called `"version"` with a single `"version"` column with your latest migration version value. Also need to replace `-- +micrate Up/Down` with `-- !migrate up/down`, which is more universal.

Cheers.