### PR TITLE
Adds mosquito

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
 
 ## Queues and Messaging
  * [dispatch](https://github.com/bmulvihill/dispatch) - In memory asynchronous job processing
+ * [mosquito](https://github.com/robacarp/mosquito/) - Redis backed periodic and ad hoc job processing
  * [sidekiq.cr](https://github.com/mperham/sidekiq.cr) - Simple, efficient job processing
 
 ## Routing

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
   * [Package Management](#package-management)
   * [Processes and Threads](#processes-and-threads)
   * [Project Generators](#project-generators)
-  * [Queue](#queue)
+  * [Queues and Messaging](#queues-and-messaging)
   * [Routing](#routing)
   * [Scheduling](#scheduling)
   * [Science and Data analysis](#science-and-data-analysis)

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [libgen](https://github.com/olbat/libgen) - Automatic bindings generator configured using JSON/YAML files
  * [wasp](https://github.com/icyleaf/wasp) - Static Site Generator
 
-## Queue
+## Queues and Messaging
  * [dispatch](https://github.com/bmulvihill/dispatch) - In memory asynchronous job processing
  * [sidekiq.cr](https://github.com/mperham/sidekiq.cr) - Simple, efficient job processing
 


### PR DESCRIPTION
I'm not sure if this is the right places in the list, but I've added [my mosquito project](https://github.com/robacarp/mosquito/) to the Queue section. It also includes jobs which are scheduled (eg every X minutes), so I considered putting it in the `Scheduling` section, but it is intended firstly as a replacement for sidekiq so I put it alongside.