### PR TITLE
Added migro

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [crecto-admin](https://github.com/Crecto/crecto-admin) - Admin dashboard for Crecto and your database
  * [micrate](https://github.com/juanedi/micrate) - Database migration tool
  * [migrate](https://github.com/vladfaust/migrate.cr) - A simpler database migration tool with transactions
- * [migro](https://github.com/aisrael/migro) - A database migration tool that allows both SQL and YAML migrations
+ * [migro](https://github.com/aisrael/migro) - A database migration tool that allows migrations to be specified in either YAML or raw SQL
 
 ## Development Tools
  * [guardian](https://github.com/f/guardian) - File change watcher for Crystal and Non-Crystal libs

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [crecto-admin](https://github.com/Crecto/crecto-admin) - Admin dashboard for Crecto and your database
  * [micrate](https://github.com/juanedi/micrate) - Database migration tool
  * [migrate](https://github.com/vladfaust/migrate.cr) - A simpler database migration tool with transactions
- * [migro](https://github.com/aisrael/migro) - A database migration tool written in Crystal
+ * [migro](https://github.com/aisrael/migro) - A database migration tool
 
 ## Development Tools
  * [guardian](https://github.com/f/guardian) - File change watcher for Crystal and Non-Crystal libs

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [crecto-admin](https://github.com/Crecto/crecto-admin) - Admin dashboard for Crecto and your database
  * [micrate](https://github.com/juanedi/micrate) - Database migration tool
  * [migrate](https://github.com/vladfaust/migrate.cr) - A simpler database migration tool with transactions
- * [migro](https://github.com/aisrael/migro) - A database migration tool
+ * [migro](https://github.com/aisrael/migro) - A database migration tool that allows both SQL and YAML migrations
 
 ## Development Tools
  * [guardian](https://github.com/f/guardian) - File change watcher for Crystal and Non-Crystal libs

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [crecto-admin](https://github.com/Crecto/crecto-admin) - Admin dashboard for Crecto and your database
  * [micrate](https://github.com/juanedi/micrate) - Database migration tool
  * [migrate](https://github.com/vladfaust/migrate.cr) - A simpler database migration tool with transactions
+ * [migro](https://github.com/aisrael/migro) - A database migration tool written in Crystal
 
 ## Development Tools
  * [guardian](https://github.com/f/guardian) - File change watcher for Crystal and Non-Crystal libs


### PR DESCRIPTION
I wrote migro as I wanted a better SQL migration tool than e.g. Liquibase or Flyway. While there are existing database migration tools written in Crystal already, they're limited to migrations written in SQL.

With migro, you can specify migrations in YAML or SQL. In the future, I hope to support automatic rollback for migrations written in YAML (ala ActiveRecord Migrations).