### PR TITLE
Add scry and mint

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,6 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [cppize](https://github.com/unn4m3d/cppize) - Crystal-to-C++ transpiler
  * [crisp](https://github.com/rhysd/Crisp) - Lisp dialect implemented with Crystal
  * [crow](https://github.com/geppetto-apps/crow) - Transpile/compile Crystal to [Flow](https://flow.org/)
- * [mint](https://github.com/mint-lang/mint) - A refreshing programming language for the font-end web
  * [myst-lang](https://github.com/myst-lang/) - A practical, dynamic language designed to be written and understood as easily and efficiently as possible
  * [NuummiteOS](https://github.com/TheKernelCorp/NuummiteOS) - An OS written in Crystal as a Proof of Concept
  * [zir](https://github.com/tbrand/zir) - Realizes to write macros in any scripts into any languages

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [cppize](https://github.com/unn4m3d/cppize) - Crystal-to-C++ transpiler
  * [crisp](https://github.com/rhysd/Crisp) - Lisp dialect implemented with Crystal
  * [crow](https://github.com/geppetto-apps/crow) - Transpile/compile Crystal to [Flow](https://flow.org/)
+ * [mint](https://github.com/mint-lang/mint) - A refreshing programming language for the font-end web
  * [myst-lang](https://github.com/myst-lang/) - A practical, dynamic language designed to be written and understood as easily and efficiently as possible
  * [NuummiteOS](https://github.com/TheKernelCorp/NuummiteOS) - An OS written in Crystal as a Proof of Concept
  * [zir](https://github.com/tbrand/zir) - Realizes to write macros in any scripts into any languages
@@ -551,6 +552,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * Emacs
    * [emacs-crystal-mode](https://github.com/dotmilk/emacs-crystal-mode) - Crystal language support for Emacs
    * [play-crystal.el](https://github.com/veelenga/play-crystal.el) - [play.crystal-lang.org](https://play.crystal-lang.org/#/cr) integration in Emacs
+ * [scry](https://github.com/crystal-lang-tools/scry) - Code analysis server for Crystal implementing the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/)
  * Spacemacs
    * [crystal-spacemacs-layer](https://github.com/juanedi/crystal-spacemacs-layer) - Spacemacs contribution layer for Crystal
  * Sublime


### PR DESCRIPTION
Hi @veelenga 

This PR adds 2 new shads:

1. Scry - LSP for crystal https://github.com/crystal-lang-tools/scry
2. ~~Mint - A refreshing programming language for the font-end web. https://www.mint-lang.com~~
