### PR TITLE
Add burocracia.cr to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [aasm.cr](https://github.com/veelenga/aasm.cr) - Easy to use finite state machine for Crystal classes
  * [accord](https://github.com/neovintage/accord) - Sharable validations for Crystal objects
  * [any_hash.cr](https://github.com/Sija/any_hash.cr) - Recursive Hash with better JSON::Any included
+ * [burocracia.cr](https://github.com/vnbrs/burocracia.cr) - burocracia.cr the dependecyless shard to validate, generate and format Brazilian burocracias such as CPF, CNPJ and CEP
  * [circuit_breaker](https://github.com/TPei/circuit_breaker) - Implementation of the circuit breaker pattern
  * [crystal-binary_parser](https://github.com/DanSnow/crystal-binary_parser) - Binary parser
  * [crystal-futures](https://github.com/dhruvrajvanshi/crystal-futures) - Future type implementation


### PR DESCRIPTION
burocracia.cr is a Crystal shard to validate, generate and format Brazilian documents (called "_burocracias_") such as CPF, CNPJ and CEP.

I'm planning to implement more _burocracias_, but these I've mentioned is the most used.

Repo: https://github.com/vnbrs/burocracia.cr
Wiki: https://vnbrs.github.io/burocracia.cr/