### PR TITLE
add crystal_faas_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [soegen](https://github.com/Ragmaanir/soegen) - Elasticsearch client for Crystal similar to the stretcher gem for ruby
 
 ## Serverless Computing
+ * [crystal_openfaas](https://github.com/TPei/crystal_openfaas/) - Template to enable crystal as first class citizens in OpenFaaS
  * [gcf.cr](https://github.com/sam0x17/gcf.cr) - Managed execution of Crystal in Google Cloud Functions
 
 ## System


### PR DESCRIPTION
I created a template implementation so that Crystal can be used with openFaaS just like other first-class citizens (like go and ruby)