### PR TITLE
Add HTTP::Params::Serializable

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [halite](https://github.com/icyleaf/halite) - Crystal HTTP Requests with a chainable REST API, built-in sessions and loggers
  * [helmet](https://github.com/EvanHahn/crystal-helmet) - Set security-related HTTP headers
  * [http-multiserver.cr](https://github.com/vladfaust/http-multiserver.cr) - Mounting multiple servers via routes (a.k.a. URL mapping)
+ * [http-params-serializable](https://github.com/vladfaust/http-params-serializable) - HTTP params (de)serialization, applicable to URL queries and URL-encoded forms
  * [http-protection](https://github.com/rogeriozambon/http-protection) - Protection against typical web attacks
  * [http2](https://github.com/ysbaddaden/http2) - HTTP/2 Protocol Implementation
  * [HTTP::Client](https://crystal-lang.org/api/HTTP/Client.html) - HTTP client (Crystal stdlib)


### PR DESCRIPTION
[http-params-serialializable](https://github.com/vladfaust/http-params-serializable) shard adds the `HTTP::Params::Serializable` module similar to `JSON::Serializable` and its siblings, which allows to (de)serialize URL queries and URL-encoded forms like a boss :sunglasses: 

It is used in [Onyx::REST](https://github.com/onyxframework/rest) to implement type-safe params.