### PR TITLE
Replace Prism with Onyx::REST

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [kemal](https://github.com/kemalcr/kemal) - Lightning Fast, Super Simple web framework. Inspired by Sinatra
  * [lattice-core](https://github.com/jasonl99/lattice-core) - A WebSocket-first object-oriented framework (based on Kemal)
  * [lucky](https://github.com/luckyframework/lucky) - Catch bugs early, forget about most performance issues, and spend more time on code instead of debugging and writing tests
- * [prism](https://github.com/vladfaust/prism) - Lightspeed web framework with typed params
+ * [onyx-rest](https://github.com/onyxframework/rest) - REST API framework with type-safe params and separate business and rendering layers, based on [onyx-http](https://github.com/onyxframework/http)
  * [raze](https://github.com/samueleaton/raze) - Modular, light web framework
  * [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) - A Rails esque web framework with a focus on speed and extensibility
 


### PR DESCRIPTION
[Onyx::REST](https://github.com/onyxframework/rest) (previously *Prism*) is a REST API framework with type-safe params and separate layers -- business with `Action`s and rendering with `View`s. It is based on [Onyx::HTTP](https://github.com/onyxframework/http) (there will be Onyx::GraphQL which would also be based on Onyx::HTTP, that's why I'm emphasizing it).