### PR TITLE
add docker-crystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [migro](https://github.com/aisrael/migro) - A database migration tool that allows migrations to be specified in either YAML or raw SQL
 
 ## Development Tools
+ * [docker-crystal](https://github.com/aca-labs/docker-crystal) - Docker wrapper for the Crystal CLI
  * [guardian](https://github.com/f/guardian) - File change watcher for Crystal and Non-Crystal libs
  * [kemal-watcher](https://github.com/faustinoaq/kemal-watcher) - Kemal plugin to watch files and live-reload the browser
  * [sentry](https://github.com/samueleaton/sentry) - Watches src files, rebuilds/reruns application on file changes


### PR DESCRIPTION
Adds Development Tools -> [docker-crystal](https://github.com/aca-labs/docker-crystal): a docker wrapper for the Crystal CLI.