### PR TITLE
add tallboy to CLI Utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
 ## CLI Utils
  * [cride](https://github.com/j8r/cride) - A light CLI text editor/IDE
  * [progress_bar.cr](https://github.com/TPei/progress_bar.cr) - A simple and customizable progress bar
+ * [tallboy](https://github.com/epoch/tallboy) - Generate ASCII character tables with support for spanning cells over multiple columns
  * [terminal_table.cr](https://github.com/benoist/terminal_table.cr) - Simple ASCII table generator
  * [todo](https://git.sceptique.eu/Sceptique/todo) - Todo list working in command line
 


### PR DESCRIPTION
tallboy is a library for generating ASCII character tables with support for spanning cells over multiple columns. Which is a feature missing even in similar popular libraries in goland, js, python & ruby
https://github.com/epoch/tallboy