### PR TITLE
add 'ish'

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [edits.cr](https://github.com/tcrouch/edits.cr) - Collection of edit distance algorithms
  * [graphlb](https://github.com/mettuaditya/graphlb) - Collection of graph datastructure and algorithms
  * [hash_ring](https://github.com/TobiasGSmollett/hash_ring) - An Implementation of Consistent Hash Ring
- * [ish](https://github.com/aca-labs/ish) - Probabilistic data structures for good-ish computation.
+ * [ish](https://github.com/aca-labs/ish) - Probabilistic data structures for good-ish computation
  * [ksuid.cr](https://github.com/Sija/ksuid.cr) - K-Sortable Globally Unique IDs
  * [markov](https://github.com/mccallofthewild/markov) - Build Markov Chains and run Markov Processes
  * [multiset.cr](https://github.com/tcrouch/multiset.cr) - Implementation of a multiset

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [edits.cr](https://github.com/tcrouch/edits.cr) - Collection of edit distance algorithms
  * [graphlb](https://github.com/mettuaditya/graphlb) - Collection of graph datastructure and algorithms
  * [hash_ring](https://github.com/TobiasGSmollett/hash_ring) - An Implementation of Consistent Hash Ring
+ * [ish](https://github.com/aca-labs/ish) - Probabilistic data structures for good-ish computation.
  * [ksuid.cr](https://github.com/Sija/ksuid.cr) - K-Sortable Globally Unique IDs
  * [markov](https://github.com/mccallofthewild/markov) - Build Markov Chains and run Markov Processes
  * [multiset.cr](https://github.com/tcrouch/multiset.cr) - Implementation of a multiset


### PR DESCRIPTION
Add ['ish'](https://github.com/aca-labs/ish) - a library of probabilistic data structures.

Currently contains an implementation of count min sketch, and will be expanded with other common probabilistic structures as time allows / needs arise.