### PR TITLE
use the mongo.cr shard from ambercommunity

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [crystal-sqlite3](https://github.com/crystal-lang/crystal-sqlite3) - SQLite3 bindings
  * [eventql-crystal](https://github.com/measurechina/eventql-crystal) - EventQL driver
  * [leveldb](https://github.com/crystal-community/leveldb) - Crystal bindings for LevelDB
- * [mongo.cr](https://github.com/datanoise/mongo.cr) - Binding for MongoDB C driver
+ * [mongo.cr](https://github.com/ambercommunity/mongo.cr) - Binding for MongoDB C driver
  * [rocksdb.cr](https://github.com/maiha/rocksdb.cr) - RocksDB client
  * [tarantool-crystal](https://github.com/vladfaust/tarantool-crystal) - Tarantool driver
 


### PR DESCRIPTION
The datanoise/mongo.cr shard, which hasn't been updated for 11 months as of April 2019,
has been forked into Amber Community organisation and commits applied from a number of other forks to bring it up to date.  In particular update to support crystal 0.27.1.