### PR TITLE
Add connect-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
 
 ## Network Protocols
  * [bson.cr](https://github.com/jeromegn/bson.cr) - Native BSON implementation
+ * [connect-proxy](https://github.com/spider-gazelle/connect-proxy) - Connect method style of HTTP tunnelling / HTTP proxy
  * [cr-xmpp](https://github.com/naqvis/cr-xmpp) - XMPP/Jabber Library
  * [Crirc](https://github.com/Meoowww/Crirc) - IRC protocol implementation (Client, Server, Bots)
  * [crystal-json-socket](https://github.com/foi/crystal-json-socket) - JSON-socket client & server implementation. Inspired by and compatible with [node-json-socket](https://github.com/sebastianseilund/node-json-socket/) and [ruby-json-socket](https://github.com/foi/ruby-json-socket)


### PR DESCRIPTION
Implements the HTTP CONNECT method for tunnelling raw sockets.
Also provides a HTTP Client implementation that can be used for connecting to HTTP servers via a connect proxy