### PR TITLE
Add PR template to standardize adding new shards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Link
+<!-- A link to the shard's source -->
+
+## Description
+<!-- A short description of what the shard does -->
+
+## Checklist
+* [ ] - Shard is at least 30 days old.
+* [ ] - Shard has CI implemented.
+* [ ] - Shard has daily/weekly periodic builds (ideally with Crystal latest and nightly).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,6 @@
 ## Link
 <!-- A link to the shard's source -->
 
-## Description
-<!-- A short description of what the shard does -->
-
 ## Checklist
 * [ ] - Shard is at least 30 days old.
 * [ ] - Shard has CI implemented.


### PR DESCRIPTION
Adds a PR template to bring increased visibility to the requirements when adding a new shard; as well as making reviewing easier.