### PR TITLE
add simple_retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [monads](https://github.com/alex-lairan/monads) - Monad implementation
  * [pinger](https://github.com/spider-gazelle/pinger) - Ping IP addresses and DNS entries without requiring sudo
  * [port_midi](https://github.com/jimm/crystal_port_midi) - Crystal C bindings for the PortMIDI cross-platform MIDI I/O library
- * [simple_retry](https://github.com/spider-gazelle/simple_retry) - Simple DSL to retry failed code blocks
+ * [retriable.cr](https://github.com/Sija/retriable.cr) - Simple DSL to retry failed code blocks
+ * [simple_retry](https://github.com/spider-gazelle/simple_retry) - Simple tool for retrying failed code blocks
  * [ulid](https://github.com/SuperPaintman/ulid) - Universally Unique Lexicographically Sortable Identifier (ULID)
  * [zaru_crystal](https://github.com/szTheory/zaru_crystal) - Filename sanitization
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [monads](https://github.com/alex-lairan/monads) - Monad implementation
  * [pinger](https://github.com/spider-gazelle/pinger) - Ping IP addresses and DNS entries without requiring sudo
  * [port_midi](https://github.com/jimm/crystal_port_midi) - Crystal C bindings for the PortMIDI cross-platform MIDI I/O library
- * [retriable.cr](https://github.com/Sija/retriable.cr) - Simple DSL to retry failed code blocks
+ * [simple_retry](https://github.com/spider-gazelle/simple_retry) - Simple DSL to retry failed code blocks
  * [ulid](https://github.com/SuperPaintman/ulid) - Universally Unique Lexicographically Sortable Identifier (ULID)
  * [zaru_crystal](https://github.com/szTheory/zaru_crystal) - Filename sanitization
 


### PR DESCRIPTION
retriable.cr is not fit for purpose in its current state https://github.com/Sija/retriable.cr/issues/8
we built a simplified version after we discovered the issue above. It was causing havoc with our services

## Link
https://github.com/spider-gazelle/simple_retry

## Checklist
* [x] - Shard is at least 30 days old.
* [x] - Shard has CI implemented.
* [x] - Shard has daily/weekly periodic builds (ideally with Crystal latest and nightly).
