### PR TITLE
Update vim-crystal repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * TextMate
    * [Crystal.tmbundle](https://github.com/crystal-lang-tools/Crystal.tmbundle) - Crystal syntax highlighting, compile, format command, snippets
  * Vim
-   * [vim-crystal](https://github.com/rhysd/vim-crystal) - Vim filetype support for Crystal
+   * [vim-crystal](https://github.com/vim-crystal/vim-crystal) - Vim filetype support for Crystal
    * [vim-slang](https://github.com/elorest/vim-slang) - Vim filetype support for Slang Templating Engine
  * Visual Studio Code
    * [vscode-crystal](https://github.com/g3ortega/vscode-crystal) - Crystal language support in VSCode


### PR DESCRIPTION
## Link
https://github.com/vim-crystal/vim-crystal

## Checklist
* [ ] - Shard is at least 30 days old.
* [ ] - Shard has CI implemented.
* [ ] - Shard has daily/weekly periodic builds (ideally with Crystal latest and nightly).

I moved [vim-crystal](https://github.com/vim-crystal/vim-crystal) to new organization. This PR updates the repository URL.