### PR TITLE
Fix stdlib compression links

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,11 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
 
 ## Compression
  * [Crystar](https://github.com/naqvis/crystar) - Readers and writers of Tar archive format
- * [Gzip](https://crystal-lang.org/api/Gzip.html) - readers and writers of gzip format (Crystal stdlib)
+ * [Gzip](https://crystal-lang.org/api/Compress/Gzip.html) - readers and writers of gzip format (Crystal stdlib)
  * [polylines.cr](https://github.com/BuonOmo/polylines.cr) — compression of series of coordinates
  * [snappy](https://github.com/naqvis/snappy) -  Snappy compression format reader/writer for Crystal
- * [Zip](https://crystal-lang.org/api/Zip.html) - readers and writers of zip format (Crystal stdlib)
- * [Zlib](https://crystal-lang.org/api/Zlib.html) - readers and writers of zlib format (Crystal stdlib)
+ * [Zip](https://crystal-lang.org/api/Compress/Zip.html) - readers and writers of zip format (Crystal stdlib)
+ * [Zlib](https://crystal-lang.org/api/Compress/Zlib.html) - readers and writers of zlib format (Crystal stdlib)
  * [zstd.cr](https://github.com/didactic-drunk/zstd.cr) - Bindings for [Zstandard](https://github.com/facebook/zstd) compression library
 
 ## Configuration


### PR DESCRIPTION
The links for `Gzip`, `Zip`, and `Zlib` were broken. They're now part of `Compress`.

(I checked the rest of the links to `crystal-lang.org` and all of the others looked right to me.)