### PR TITLE
Add the CSUUID shards to the algorithms list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [crystaledge](https://github.com/unn4m3d/crystaledge) - A pure Vector Math library
  * [crystalg](https://github.com/tobyapi/crystalg) - A Generic Algorithm Library
  * [crystalline](https://github.com/jtomschroeder/crystalline) - A collection of containers and algorithms
+ * [csuuid](https://github.com/wyhaines/csuuid.cr) - A Chronologically Sortable UUID
  * [edits.cr](https://github.com/tcrouch/edits.cr) - Collection of edit distance algorithms
  * [fzy](https://github.com/hugopl/fzy) - A Crystal port of awesome Fzy project fuzzy finder algorithm
  * [graphlb](https://github.com/mettuaditya/graphlb) - Collection of graph datastructure and algorithms


### PR DESCRIPTION
## Link
https://github.com/wyhaines/csuuid.cr

## Checklist
* [x] - Shard is at least 30 days old.
* [x] - Shard has CI implemented.
* [x] - Shard has daily/weekly periodic builds (ideally with Crystal latest and nightly).

This shard is one of my older ones, and has been in use in myriad other places for a couple years. I just did a little doc cleanup, and bumped it to 1.0.0.