### PR TITLE
Add Amazonite library

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ described in [RFC 8032]
  * [webmock.cr](https://github.com/manastech/webmock.cr) - Library for stubbing `HTTP::Client` requests
 
 ## Third-party APIs
- * [amazonite](https://github.com/rjnienaber/amazonite) - An unofficial SDK supporting popular AWS APIs.
+ * [amazonite](https://github.com/rjnienaber/amazonite) - An unofficial SDK supporting popular AWS APIs
  * [aws-signer.cr](https://github.com/beanieboi/aws-signer.cr) - This library signs your HTTP requests using AWS v4
  * [awscr-s3](https://github.com/taylorfinnell/awscr-s3) - AWS S3 interface
  * [awscr-signer](https://github.com/taylorfinnell/awscr-signer) - Sign HTTP::Request objects and generate presigned post forms

--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ described in [RFC 8032]
  * [webmock.cr](https://github.com/manastech/webmock.cr) - Library for stubbing `HTTP::Client` requests
 
 ## Third-party APIs
+ * [amazonite](https://github.com/rjnienaber/amazonite) - An unofficial SDK supporting popular AWS APIs.
  * [aws-signer.cr](https://github.com/beanieboi/aws-signer.cr) - This library signs your HTTP requests using AWS v4
  * [awscr-s3](https://github.com/taylorfinnell/awscr-s3) - AWS S3 interface
  * [awscr-signer](https://github.com/taylorfinnell/awscr-signer) - Sign HTTP::Request objects and generate presigned post forms


### PR DESCRIPTION
An unofficial SDK supporting popular AWS APIs.

## Link
https://github.com/rjnienaber/amazonite

## Checklist
* [X] - Shard is at least 30 days old.
* [X] - Shard has CI implemented.
* [X] - Shard has daily/weekly periodic builds (ideally with Crystal latest and nightly).
