### PR TITLE
fix Crystal Shards link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A curated list of awesome Crystal code and resources. Inspired by [awesome](https://github.com/sindresorhus/awesome) and [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness).
 The goal is to have projects mostly stable and useful for the community.
 
-Search [Crystal Shards](https://crystalshards.xyz) or follow announcements [Crystal [ANN]](https://crystal-ann.com) for more.
+Search [Crystal Shards](https://crystalshards.org) or follow announcements [Crystal [ANN]](https://crystal-ann.com) for more.
 
 Contributions are welcome. Please take a quick look at the [contribution guidelines](https://github.com/veelenga/awesome-crystal/blob/master/.github/CONTRIBUTING.md) first.
 


### PR DESCRIPTION
https://crystalshards.xyz isn't working anymore.
https://crystalshards.herokuapp.com isn't working too

https://crystalshards.org works.