### PR TITLE
add v4l2

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [pledge.cr](https://github.com/chris-huxtable/pledge.cr) - Bindings for OpenBSD's `pledge(2)`
  * [ssh2.cr](https://github.com/spider-gazelle/ssh2.cr) - Bindings for libssh2 library
  * [syslog.cr](https://github.com/chris-huxtable/syslog.cr) - Bindings for `syslog`
+ * [v4l2.cr](https://github.com/spider-gazelle/v4l2.cr) - Bindings for [Video4Linux2](https://en.wikipedia.org/wiki/Video4Linux)
  * [wasmer-crystal](https://github.com/naqvis/wasmer-crystal) - Bindings for the `wasmer` WebAssembly runtime
  * [x_do.cr](https://github.com/woodruffw/x_do.cr) - Bindings for libxdo ([`xdotool`](https://github.com/jordansissel/xdotool))
 


### PR DESCRIPTION
## Link
https://github.com/spider-gazelle/v4l2.cr

## Checklist
* [x] - Shard is at least 30 days old.
* [x] - Shard has CI implemented.
* [x] - Shard has daily/weekly periodic builds (ideally with Crystal latest and nightly).

No CI setup as kernel modules can't be loaded in github actions. It does have specs though