### PR TITLE
Replace Weekly newsletter with official newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ described in [RFC 8032]
  * [Chicago Crystal Podcast](https://podcast.chicagocrystal.org)
  * [Chicago Crystal YouTube](https://www.youtube.com/channel/UCI1RvHPG6S9mw4eRoJfH2kA)
  * [Crystal Forum](https://forum.crystal-lang.org/)
- * [Crystal weekly newsletters](http://crystalweekly.com/)
+ * [Crystal newsletters](https://crystal-lang.org/#newsletter)
  * [Gitter](https://gitter.im/crystal-lang/crystal)
  * [Google Group](https://groups.google.com/forum/?fromgroups#!forum/crystal-lang)
  * [IRC](http://irc.lc/freenode/crystal-lang) - #crystal-lang on Freenode


### PR DESCRIPTION
The last Crystal Weekly Newsletter was on 2022.
There is a new section on the official page to subscribe https://crystal-lang.org/#newsletter.
