### PR TITLE
Removes defunct community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,8 @@ described in [RFC 8032]
 # Community
  * [Crystal Forum](https://forum.crystal-lang.org/)
  * [Crystal newsletter](https://crystal-lang.org/#newsletter)
+ * [Gitter](https://gitter.im/crystal-lang/crystal)
+ * [IRC](ircs://irc.libera.chat:6697#crystal-lang) - #crystal-lang on Libera 
  * [Reddit](https://www.reddit.com/r/crystal_programming/)
  * [Stackoverflow](https://stackoverflow.com/tags/crystal-lang/info)
 

--- a/README.md
+++ b/README.md
@@ -541,13 +541,8 @@ described in [RFC 8032]
  * [spider-gazelle](https://github.com/spider-gazelle/spider-gazelle) - A Rails esque web framework with a focus on speed and extensibility
 
 # Community
- * [Chicago Crystal Podcast](https://podcast.chicagocrystal.org)
- * [Chicago Crystal YouTube](https://www.youtube.com/channel/UCI1RvHPG6S9mw4eRoJfH2kA)
  * [Crystal Forum](https://forum.crystal-lang.org/)
- * [Crystal newsletters](https://crystal-lang.org/#newsletter)
- * [Gitter](https://gitter.im/crystal-lang/crystal)
- * [Google Group](https://groups.google.com/forum/?fromgroups#!forum/crystal-lang)
- * [IRC](http://irc.lc/freenode/crystal-lang) - #crystal-lang on Freenode
+ * [Crystal newsletter](https://crystal-lang.org/#newsletter)
  * [Reddit](https://www.reddit.com/r/crystal_programming/)
  * [Stackoverflow](https://stackoverflow.com/tags/crystal-lang/info)
 

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ described in [RFC 8032]
  * [Crystal Forum](https://forum.crystal-lang.org/)
  * [Crystal newsletter](https://crystal-lang.org/#newsletter)
  * [Gitter](https://gitter.im/crystal-lang/crystal)
- * [IRC](ircs://irc.libera.chat:6697#crystal-lang) - #crystal-lang on Libera 
+ * [IRC](ircs://irc.libera.chat:6697#crystal-lang) - #crystal-lang on Libera
  * [Reddit](https://www.reddit.com/r/crystal_programming/)
  * [Stackoverflow](https://stackoverflow.com/tags/crystal-lang/info)
 


### PR DESCRIPTION
Several of these have been inactive for 3+ years. I think having links to defunct community projects makes crystal a bit bruised.
