### PR TITLE
add libgpio bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [duktape.cr](https://github.com/jessedoyle/duktape.cr) - Bindings for the [Duktape](https://github.com/svaarala/duktape) javascript engine
  * [fftw.cr](https://github.com/firejox/fftw.cr) - Bindings for [FFTW](https://fftw.org/) library
  * [gphoto2.cr](https://github.com/Sija/gphoto2.cr) - Bindings for the [libgphoto2](http://www.gphoto.org/) library
+ * [gpio.cr](https://github.com/spider-gazelle/gpio.cr) - Bindings for the gpiod library (general purpose IO control and feedback)
  * [icu.cr](https://github.com/olbat/icu.cr) - Bindings for the [ICU](http://site.icu-project.org/) library
  * [libnotify.cr](https://github.com/splattael/libnotify.cr) - Bindings for Libnotify
  * [nlopt.cr](https://github.com/konovod/nlopt.cr) - Bindings for [NLOpt](https://nlopt.readthedocs.io/en/latest/)


### PR DESCRIPTION
add [gpio.cr](https://github.com/spider-gazelle/gpio.cr) linux general purpose IO bindings
useful for controlling and getting feedback on raspberry pi IO headers

## Link

https://github.com/spider-gazelle/gpio.cr

## Checklist
* [x] - Shard is at least 30 days old.
* [ ] - Shard has CI implemented
* [ ] - Shard has daily/weekly periodic builds (ideally with Crystal latest and nightly).

no CI as requires hardware but there are tests implemented and working in production projects such as my [chicken door](https://vontaka.ch/chicken_door/)