### PR TITLE
Recommend Lexbor over MyHTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ described in [RFC 8032]
 
 ## HTML/XML Parsing
  * [docx_cr_converter](https://github.com/aristotelesbr/docx_cr_converter) - parse DOCX Word
- * [myhtml](https://github.com/kostya/myhtml) - Fast HTML5 Parser that includes CSS selectors
+ * [lexbor](https://github.com/kostya/lexbor) - Fast HTML5 Parser that includes CSS selectors
 
 ## HTTP
  * [Cable](https://github.com/cable-cr/cable) - An ActionCable "port" to Crystal, framework agnostic, 100% compatible with the ActionCable JS Client


### PR DESCRIPTION
Recommend Lexbor over MyHTML, because the [Github README](https://github.com/kostya/myhtml?tab=readme-ov-file#warning-original-libraries-myhtml-and-modest-not-maintained-since-july-2020-i-recommend-switch-to-successor-parser-lexbor) of MyHTML says:

> WARNING: original libraries (myhtml and Modest) not maintained since july 2020, i recommend switch to successor parser: Lexbor.

## Link

https://github.com/kostya/lexbor

## Checklist
* [x] - Shard is at least 30 days old.
* [x] - Shard has CI implemented.
* [ ] - Shard has daily/weekly periodic builds (ideally with Crystal latest and nightly).
