### PR TITLE
Fix segfault in groups method

### DIFF
--- a/util/readme.cr
+++ b/util/readme.cr
@@ -27,8 +27,11 @@ class Readme
   def groups
     set = find("//ul[li]").as XML::NodeSet
     set.map do |node|
-      n = XML.parse(node.to_s).xpath("/ul/li/a[1]/text()").as XML::NodeSet
-      n.map { |el| el.text.as String }
+      list_items = node.xpath("./li").as XML::NodeSet
+      list_items.map do |li|
+        first_link = li.xpath("./a[1]").as XML::NodeSet
+        first_link.first?.try(&.content) || ""
+      end.reject(&.empty?)
     end
   end
 


### PR DESCRIPTION
## Summary
- Fixed segfault in `Readme#groups` method caused by reparsing XML fragments
- Replaced `XML.parse(node.to_s)` with relative XPath on existing parsed nodes
- Added safe navigation to handle missing elements gracefully

## Problem
The original code created malformed XML documents by reparsing fragments, causing segfaults during XPath evaluation in libxml2.

## Solution
Use relative XPath (`./li`, `./a[1]`) on already-parsed nodes instead of creating new XML documents.

🤖 Generated with [Claude Code](https://claude.ai/code)