### PR TITLE
Add shiny_json_logic to Data Formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ described in [RFC 8032]
  * [jmespath.cr](https://github.com/qequ/jmespath.cr) - Crystal implementation of JMESPath, a query language for JSON
  * [JSON](https://crystal-lang.org/api/JSON.html) - parsing and generating JSON documents (Crystal stdlib)
  * [json-schema](https://github.com/spider-gazelle/json-schema) - convert JSON serializable classes into a [JSON Schema](https://json-schema.org/) representation
+ * [shiny_json_logic](https://github.com/luismoyano/shiny-json-logic-crystal) - Zero-dependency JSON Logic implementation passing 100% of the official test suite
  * [JSON::OnSteroids](https://github.com/anykeyh/json_on_steroids) - handle and mutate JSON document easily
  * [maxminddb.cr](https://github.com/delef/maxminddb.cr) - MaxMindDB reader
  * [toml.cr](https://github.com/crystal-community/toml.cr) - TOML parser


### PR DESCRIPTION
## Description

Adds [shiny_json_logic](https://github.com/luismoyano/shiny-json-logic-crystal) to the **Data Formats** section.

**shiny_json_logic** is a pure Crystal, zero-dependency implementation of [JSON Logic](https://jsonlogic.com/) — a portable rule engine that lets you express business logic as plain JSON and evaluate it safely against data.

- ✅ Passes all 601 official JSON Logic tests (100% compliance)
- 🧩 Zero runtime dependencies — stdlib only
- ⚡ ~692k ops/second on Crystal 1.14 Linux
- Crystal 1.0+

Part of the [Shiny JSON Logic](https://shinyjsonlogic.com) family (also available for Ruby and PHP).

## Checklist
[] - Shard is at least 30 days old.
[x] - Shard has CI implemented.
[x] - Shard has daily/weekly periodic builds (ideally with Crystal latest and nightly).