### PR TITLE
Add ucl.cr

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [envyable](https://github.com/philnash/envyable.cr) -  A simple YAML to ENV config loader
  * [habitat](https://github.com/luckyframework/habitat) - Type safe configuration for your classes and modules
  * [totem](https://github.com/icyleaf/totem) - Load and parse a configuration in JSON, YAML, dotenv formats
+ * [ucl.cr](https://github.com/jbox-web/ucl.cr) - Bindings to [libucl](https://github.com/vstakhov/libucl), load, dump and validate UCL/JSON configuration
 
 ## Converters
  * [base62.cr](https://github.com/Sija/base62.cr) - Base62 encoder/decoder, well suited for url-shortening


### PR DESCRIPTION
Adds [ucl.cr](https://github.com/jbox-web/ucl.cr) to the **Configuration** section.

ucl.cr is a Crystal shard providing bindings to [libucl](https://github.com/vstakhov/libucl), the universal configuration language. It lets you:

* **load** UCL/JSON configuration into native Crystal values
* **dump** Crystal objects back to UCL, JSON, YAML or MsgPack
* **validate** data against a UCL/JSON schema

Checklist:
- [x] Entry added alphabetically within the section
- [x] Clear and concise description, no duplicates
- [x] Actively maintained with CI (monthly cron build against latest stable Crystal)
- [x] Specs pass (`crystal spec`)