### PR TITLE
Add wgpu-cr (WebGPU / wgpu-native bindings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Contributions are welcome. Please take a quick look at the [contribution guideli
  * [syslog.cr](https://github.com/chris-huxtable/syslog.cr) - Bindings for `syslog`
  * [v4l2.cr](https://github.com/spider-gazelle/v4l2.cr) - Bindings for [Video4Linux2](https://en.wikipedia.org/wiki/Video4Linux)
  * [wasmer-crystal](https://github.com/naqvis/wasmer-crystal) - Bindings for the `wasmer` WebAssembly runtime
+ * [wgpu-cr](https://github.com/raj/wgpu-cr) - Bindings for [wgpu-native](https://github.com/gfx-rs/wgpu-native) (WebGPU)
  * [win32cr](https://github.com/mjblack/win32cr) - Bindings for Win32 API
  * [x_do.cr](https://github.com/woodruffw/x_do.cr) - Bindings for libxdo ([`xdotool`](https://github.com/jordansissel/xdotool))
 


### PR DESCRIPTION
Adds [wgpu-cr](https://github.com/raj/wgpu-cr) to **C bindings**.

Crystal bindings for wgpu-native (WebGPU): a low-level `LibWGPU` FFI generated from `webgpu.h` plus an idiomatic high-level `WGPU` API. GPU compute works end-to-end and it renders a triangle on macOS/Metal. MIT-licensed, has a `shard.yml` and a tagged release, native lib fetched via postinstall.

Placed alphabetically in the C bindings section.